### PR TITLE
Fix broken nginx modsec due to owasp deleting base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@
 # docker build -t fareoffice/modsecurity:v3-nginx-crs-<CRS-VERSION> .
 # docker push fareoffice/modsecurity:v3-nginx-crs-<CRS-VERSION>
 
-FROM owasp/modsecurity:v3-ubuntu-nginx
+FROM owasp/modsecurity:3-nginx
 
-ENV CRS_PATH=/etc/nginx/modsecurity.d/owasp-crs
+ENV CRS_PATH=/etc/modsecurity.d/owasp-crs
 
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get -y install python git ca-certificates
 
-WORKDIR /etc/nginx/modsecurity.d
+WORKDIR /etc/modsecurity.d
 
 # Checking out by git sha to get version 3.0.2 of CRS
 # See https://github.com/SpiderLabs/owasp-modsecurity-crs/releases/tag/v3.0.2
@@ -39,12 +39,13 @@ RUN \
 COPY *.sh /
 RUN chmod u+x /*.sh
 
-COPY nginx.conf /etc/nginx/
+COPY nginx.conf /etc/nginx/nginx.conf
 
 # Logs to stdout/stderr
-RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
-  ln -sf /dev/stderr /var/log/nginx/error.log && \
-  ln -sf /dev/stdout /var/log/modsec_audit.log
+# RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+#   ln -sf /dev/stderr /var/log/nginx/error.log && \
+#   ln -sf /dev/stdout /var/log/modsec_audit.log
+RUN ln -sf /dev/stdout /var/log/modsec_audit.log
 
 RUN /cleanup.sh && rm -f /cleanup.sh
 
@@ -102,4 +103,4 @@ ENV PROXY_HEADER_X_FRAME_OPTIONS=SAMEORIGIN
 EXPOSE 80
 
 ENTRYPOINT ["/main.sh"]
-CMD /usr/local/nginx/nginx -g "daemon off;"
+CMD ["nginx", "-g", "daemon off;"]

--- a/main.sh
+++ b/main.sh
@@ -11,17 +11,17 @@ python -c "import re;import os;out=re.sub('(#SecAction[\S\s]*id:900330[\s\S]*tot
 echo "PARANOIA set to '${PARANOIA}'"
 
 if [ "${SEC_RULE_ENGINE}" != "" ]; then
-  sed -i".bak" "s/SecRuleEngine On/SecRuleEngine ${SEC_RULE_ENGINE}/" /etc/nginx/modsecurity.d/modsecurity.conf
+  sed -i".bak" "s/SecRuleEngine On/SecRuleEngine ${SEC_RULE_ENGINE}/" /etc/modsecurity.d/modsecurity.conf
   echo "SecRuleEngine set to '${SEC_RULE_ENGINE}'"
 fi
 
 if [ "${SEC_PRCE_MATCH_LIMIT}" != "" ]; then
-  sed -i".bak" "s/SecPcreMatchLimit 1000/SecPcreMatchLimit ${SEC_PRCE_MATCH_LIMIT}/" /etc/nginx/modsecurity.d/modsecurity.conf
+  sed -i".bak" "s/SecPcreMatchLimit 1000/SecPcreMatchLimit ${SEC_PRCE_MATCH_LIMIT}/" /etc/modsecurity.d/modsecurity.conf
   echo "SecPcreMatchLimit set to '${SEC_PRCE_MATCH_LIMIT}'"
 fi
 
 if [ "${SEC_PRCE_MATCH_LIMIT_RECURSION}" != "" ]; then
-  sed -i".bak" "s/SecPcreMatchLimitRecursion 1000/SecPcreMatchLimitRecursion ${SEC_PRCE_MATCH_LIMIT_RECURSION}/" /etc/nginx/modsecurity.d/modsecurity.conf
+  sed -i".bak" "s/SecPcreMatchLimitRecursion 1000/SecPcreMatchLimitRecursion ${SEC_PRCE_MATCH_LIMIT_RECURSION}/" /etc/modsecurity.d/modsecurity.conf
   echo "SecPcreMatchLimitRecursion set to '${SEC_PRCE_MATCH_LIMIT_RECURSION}'"
 fi
 
@@ -43,26 +43,26 @@ else
   echo "X-Frame-Options disabled"
 fi
 
-echo "" > /etc/nginx/modsecurity.d/owasp-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+echo "" > /etc/modsecurity.d/owasp-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
 names=`env | grep SEC_RULE_BEFORE_ | sed 's/=.*//'`
 if [ "$names" != "" ]; then
   while read name; do
     eval value='$'"${name}"
-    echo "${value}" >> /etc/nginx/modsecurity.d/owasp-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+    echo "${value}" >> /etc/modsecurity.d/owasp-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
   done <<< "$names"
   echo "REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf"
-  cat /etc/nginx/modsecurity.d/owasp-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+  cat /etc/modsecurity.d/owasp-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
 fi
 
-echo "" > /etc/nginx/modsecurity.d/owasp-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+echo "" > /etc/modsecurity.d/owasp-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
 names=`env | grep SEC_RULE_AFTER_ | sed 's/=.*//'`
 if [ "$names" != "" ]; then
   while read name; do
     eval value='$'"${name}"
-    echo "${value}" >> /etc/nginx/modsecurity.d/owasp-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+    echo "${value}" >> /etc/modsecurity.d/owasp-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
   done <<< "$names"
   echo "RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf"
-  cat /etc/nginx/modsecurity.d/owasp-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+  cat /etc/modsecurity.d/owasp-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
 fi
 
 echo "Starting nginx"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,138 +1,119 @@
+load_module modules/ngx_http_modsecurity_module.so;
 
-worker_processes 4;
-
+user  nginx;
+worker_processes  4;
 worker_rlimit_nofile 261120;
+worker_shutdown_timeout 10s;
 
-worker_shutdown_timeout 10s ;
+error_log  /dev/stdout warn;
+pid        /var/run/nginx.pid;
+
 
 events {
-  multi_accept        on;
-  worker_connections  16384;
-  use                 epoll;
+    multi_accept        on;
+    worker_connections  16384;
+    use                 epoll;
 }
 
+
 http {
-  client_max_body_size 1m;
+    modsecurity on;
+    modsecurity_rules_file /etc/modsecurity.d/include.conf;
 
-  real_ip_header      X-Forwarded-For;
+    client_max_body_size 1m;
+    real_ip_header      X-Forwarded-For;
 
-  real_ip_recursive   on;
+    real_ip_recursive   on;
 
-  set_real_ip_from    0.0.0.0/0;
+    set_real_ip_from    0.0.0.0/0;
 
-  aio                 threads;
-  aio_write           on;
+    aio                 threads;
+    aio_write           on;
 
-  tcp_nopush          on;
-  tcp_nodelay         on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
 
-  log_subrequest      on;
+    log_subrequest      on;
 
-  reset_timedout_connection on;
+    reset_timedout_connection on;
 
-  keepalive_timeout  140s;
-  keepalive_requests 100;
+    keepalive_timeout  140s;
+    keepalive_requests 100;
 
-  client_body_temp_path           /tmp/client-body;
-  fastcgi_temp_path               /tmp/fastcgi-temp;
-  proxy_temp_path                 /tmp/proxy-temp;
+    client_body_temp_path           /tmp/client-body;
+    fastcgi_temp_path               /tmp/fastcgi-temp;
+    proxy_temp_path                 /tmp/proxy-temp;
 
-  client_header_buffer_size       1k;
-  client_header_timeout           120s;
-  large_client_header_buffers     4 64k;
-  client_body_buffer_size         64k;
-  client_body_timeout             120s;
+    client_header_buffer_size       1k;
+    client_header_timeout           120s;
+    large_client_header_buffers     4 64k;
+    client_body_buffer_size         64k;
+    client_body_timeout             120s;
 
-  http2_max_field_size            4k;
-  http2_max_header_size           16k;
+    http2_max_field_size            4k;
+    http2_max_header_size           16k;
 
-  types_hash_max_size             2048;
-  server_names_hash_max_size      1024;
-  server_names_hash_bucket_size   32;
-  map_hash_bucket_size            128;
+    types_hash_max_size             2048;
+    server_names_hash_max_size      1024;
+    server_names_hash_bucket_size   32;
+    map_hash_bucket_size            128;
 
-  proxy_headers_hash_max_size     512;
-  proxy_headers_hash_bucket_size  64;
+    proxy_headers_hash_max_size     512;
+    proxy_headers_hash_bucket_size  64;
 
-  variables_hash_bucket_size      128;
-  variables_hash_max_size         2048;
+    variables_hash_bucket_size      128;
+    variables_hash_max_size         2048;
 
-  underscores_in_headers          off;
-  ignore_invalid_headers          on;
+    underscores_in_headers          off;
+    ignore_invalid_headers          on;
 
-  limit_req_status                503;
+    limit_req_status                503;
 
-  include /etc/nginx/mime.types;
+    include       /etc/nginx/mime.types;
+    default_type text/html;
 
-  default_type text/html;
+    gzip on;
+    gzip_comp_level 5;
+    gzip_http_version 1.1;
+    gzip_min_length 256;
+    gzip_types application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component;
+    gzip_proxied any;
+    gzip_vary on;
+    access_log  /dev/stdout;
 
-  gzip on;
-  gzip_comp_level 5;
-  gzip_http_version 1.1;
-  gzip_min_length 256;
-  gzip_types application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component;
-  gzip_proxied any;
-  gzip_vary on;
+    # Custom headers for response
+    server_tokens off;
 
-  # Custom headers for response
+    # disable warnings
+    uninitialized_variable_warn off;
 
-  server_tokens off;
-
-  # disable warnings
-  uninitialized_variable_warn off;
-
-  map $http_x_forwarded_for $the_real_ip {
-
-    default          $remote_addr;
-
-  }
-
-  access_log /dev/stdout;
-
-  error_log  off;
-
-  server {
-
-    listen 80 default_server;
-
-    listen [::]:80 default_server;
-
-    add_header X-Frame-Options SAMEORIGIN;
-
-    location / {
-      port_in_redirect off;
-
-      modsecurity on;
-
-      modsecurity_rules_file /etc/nginx/modsecurity.d/include.conf;
-
-      # Allow websocket connections
-      proxy_set_header                        Upgrade           $http_upgrade;
-
-      proxy_set_header X-Forwarded-For        $the_real_ip;
-
-      proxy_set_header X-Original-URI         $request_uri;
-
-      # Pass the original X-Forwarded-For
-      proxy_set_header X-Original-Forwarded-For $http_x_forwarded_for;
-
-      # mitigate HTTPoxy Vulnerability
-      # https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/
-      proxy_set_header Proxy                  "";
-
-      proxy_set_header Host                   $host;
-
-      proxy_pass http://127.0.0.1:3000;
-
-      proxy_redirect                          off;
+    map $http_x_forwarded_for $the_real_ip {
+      default          $remote_addr;
     }
 
-    # health checks in cloud providers require the use of port 80
-    location /healthz {
-
-      access_log off;
-      return 200;
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        add_header X-Frame-Options SAMEORIGIN;
+        location / {
+          port_in_redirect off;
+          # Allow websocket connections
+          proxy_set_header                        Upgrade           $http_upgrade;
+          proxy_set_header X-Forwarded-For        $the_real_ip;
+          proxy_set_header X-Original-URI         $request_uri;
+          # Pass the original X-Forwarded-For
+          proxy_set_header X-Original-Forwarded-For $http_x_forwarded_for;
+          # mitigate HTTPoxy Vulnerability
+          # https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/
+          proxy_set_header Proxy                  "";
+          proxy_set_header Host                   $host;
+          proxy_pass http://127.0.0.1:3000;
+          proxy_redirect                          off;
+        }
+        # health checks in cloud providers require the use of port 80
+        location /healthz {
+            access_log off;
+            return 200;
+        }
     }
-
-  }
 }

--- a/pipelines/default.yaml
+++ b/pipelines/default.yaml
@@ -9,8 +9,7 @@ pipeline:
   steps:
   - docker:
       build:
-        image: fareoffice/modsecurity:v3-nginx-crs-3.0.2-${GIT_COMMIT}
+        image: fareoffice/modsecurity:3-nginx-${GIT_COMMIT}
       tag:
-      - fareoffice/modsecurity:latest
-      - fareoffice/modsecurity:v3-nginx-crs-3.0.2
+      - fareoffice/modsecurity:3-nginx
       push: true

--- a/pipelines/git-release.yaml
+++ b/pipelines/git-release.yaml
@@ -7,4 +7,4 @@ pipeline:
   extensions:
     githubRelease:
       channel: infra-releases
-      image: fareoffice/modsecurity:v3-nginx-crs-3.0.2-${GIT_COMMIT}
+      image: fareoffice/modsecurity:3-nginx-${GIT_COMMIT}


### PR DESCRIPTION
The current modsec nginx can't be built because the base image no longer exists on docker hub. What I did was base this version of off 3-nginx tag and modified it to match both the base nginx conf and current nginx.conf file.

We tested it briefly using Olle's tests and they passed. We need to decide whether we need more tests or can go life with this.

So I won't break the current modsecurity on dockerhub I have changed the tags so current won't be overwritten, i.e. no latest (which is bad anyway) and no v3-nginx-crs-3.0.2 tag.